### PR TITLE
Fixes #25: A crash after exiting menu.

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/window/HoverMenuService.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/window/HoverMenuService.java
@@ -53,6 +53,7 @@ public abstract class HoverMenuService extends Service {
         public void onExitByUserRequest() {
             Log.d(TAG, "Menu exit requested.");
             savePreferredLocation();
+            mHoverMenu.hide();
             onHoverMenuExitingByUserRequest();
             stopSelf();
         }

--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/window/WindowHoverMenu.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/window/WindowHoverMenu.java
@@ -153,6 +153,7 @@ public class WindowHoverMenu implements HoverMenu {
 
             // Cleanup the control structures and Views.
             mWindowViewController.removeView(mHoverMenuView);
+            mHoverMenuView.release();
         }
     }
 


### PR DESCRIPTION
The problem was that the window menu wasn't being released correctly and its tap listener was sticking around after the Service and View were destroyed.