### PR TITLE
Fix how HoverMenuView.addAllTabs() handles ids

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
@@ -692,7 +692,7 @@ public class HoverMenuView extends RelativeLayout {
 
     private void addAllTabs() {
         for (int i = 0; i < mAdapter.getTabCount(); ++i) {
-            addTab(i + "", mAdapter.getTabView(i));
+            addTab(String.valueOf(mAdapter.getTabId(i)), mAdapter.getTabView(i));
         }
     }
 

--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
@@ -693,7 +693,6 @@ public class HoverMenuView extends RelativeLayout {
     private void addAllTabs() {
         for (int i = 0; i < mAdapter.getTabCount(); ++i) {
             addTab(i + "", mAdapter.getTabView(i));
-            mTabIds.add(i + "");
         }
     }
 


### PR DESCRIPTION
1. Removed the call to` mTabIds.add()` in this function.  `addTab()` also has this call, so the id is getting added twice.
2. Using the `HoverMenuAdapter.getTabId()` for the id, rather than the position.

Confirmed no regressions on the sample app scenarios.