### PR TITLE
Removing duplicate mTabIds.add() call

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
@@ -693,7 +693,6 @@ public class HoverMenuView extends RelativeLayout {
     private void addAllTabs() {
         for (int i = 0; i < mAdapter.getTabCount(); ++i) {
             addTab(i + "", mAdapter.getTabView(i));
-            mTabIds.add(i + "");
         }
     }
 


### PR DESCRIPTION
Each id is getting added twice, once in `addAllTabs` and again in `addTab`