### PR TITLE
Remove early exit from onLayout

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
@@ -604,10 +604,6 @@ public class HoverMenuView extends RelativeLayout {
         Rect anchoredBounds = mMenuAnchor.anchor(new Rect(0, 0, getActiveTab().getWidth(), getActiveTab().getHeight()));
         Log.d(TAG, "Adjusted anchor bounds at (" + anchoredBounds.left + ", " + anchoredBounds.top + ")");
 
-        if (!changed) {
-            return;
-        }
-
         // TODO: how can we avoid this null check?
         if (null != mActiveTab) {
             Log.d(TAG, "Adjusting tab position due to layout change.");


### PR DESCRIPTION
This is the same PR I initially put out for issue #34, but closed because I wanted to understand the problem more and test.

It is not safe to return early from `onLayout`, even if `changed == false`, since the adapter can raise content changed events.  This event triggers an `onLayout` call because all the old tabs are removed and new ones added to the view.  In this case, the new tabs need to be positioned.

The repro for this issue is to add content when the menu is collapsed.  Once all the old tabs are removed and new ones added, `onLayout` does not tell `mActiveTab` to position itself at the anchor.  It defaults to the top-right of the screen, and is misaligned with the `Dragger` so does not accept clicks/drags.

I've tested that this fixes the issue in my sample app [here](https://github.com/Fitzpasd/hoverbug), and I've  confirmed no regressions in project samples.