### PR TITLE
Exit early from onLayout if not changed & state is transitioning

### DIFF
--- a/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
+++ b/hover/src/main/java/io/mattcarroll/hover/defaulthovermenu/HoverMenuView.java
@@ -604,7 +604,7 @@ public class HoverMenuView extends RelativeLayout {
         Rect anchoredBounds = mMenuAnchor.anchor(new Rect(0, 0, getActiveTab().getWidth(), getActiveTab().getHeight()));
         Log.d(TAG, "Adjusted anchor bounds at (" + anchoredBounds.left + ", " + anchoredBounds.top + ")");
 
-        if (!changed) {
+        if (!changed && mVisualState == TRANSITIONING) {
             return;
         }
 


### PR DESCRIPTION
Exiting early based solely on `changed` was causing issues as described in this PR #39.  Removing the early exit entirely was causing the `CollapsedMenuViewController` to set the active tab translations before the collapse animation was started.  This caused the animation not to run.

Adding a check `mVisualState == TRANSITIONING` to this block prevents both issues.  New tabs get laid out correctly as expected, and we don't set the position of the active tab while transitioning/animating.